### PR TITLE
fix: Properly exclude Zapatos types from Kysely types

### DIFF
--- a/src/templates/kysely-types.template.ts
+++ b/src/templates/kysely-types.template.ts
@@ -1,6 +1,6 @@
 export default `import { ColumnType, Kysely } from "kysely"
 import * as schema from "zapatos/schema"
-import { SQLFragment } from "zapatos/db"
+import { Parameter, SQLFragment } from "zapatos/db"
 
 type ZapatosInsertableTypeToPrimitive<T> = Exclude<
   T,

--- a/src/templates/kysely-types.template.ts
+++ b/src/templates/kysely-types.template.ts
@@ -4,7 +4,7 @@ import { SQLFragment } from "zapatos/db"
 
 type ZapatosInsertableTypeToPrimitive<T> = Exclude<
   T,
-  symbol | SQLFragment<any> | SQLFragment<any, any> | Parameter
+  symbol | SQLFragment<any, any> | Parameter
 >
 
 export type ZapatosTableNameToKyselySchema<T extends schema.Table> = {

--- a/src/templates/kysely-types.template.ts
+++ b/src/templates/kysely-types.template.ts
@@ -2,7 +2,10 @@ export default `import { ColumnType, Kysely } from "kysely"
 import * as schema from "zapatos/schema"
 import { SQLFragment } from "zapatos/db"
 
-type ZapatosInsertableTypeToPrimitive<T> = Exclude<T, symbol | SQLFragment>
+type ZapatosInsertableTypeToPrimitive<T> = Exclude<
+  T,
+  symbol | SQLFragment<any> | SQLFragment<any, any> | Parameter
+>
 
 export type ZapatosTableNameToKyselySchema<T extends schema.Table> = {
   [K in keyof schema.SelectableForTable<T>]: ColumnType<


### PR DESCRIPTION
## Context
`SQLFragment` without params would not actually exclude all `SQLFragment` occurrences. `Parameter` types were not excluded either.
I don't think it generated a bug per se but the type generated for Kysely was incorrect regardless.

I fixed it in `seam-connect` but `seam-connect` imports `billing` which uses `seam-pgm` which duplicates the bad logic defined in `seam-connect` and causes a conflict when fixing it there 🤯  

Not sure why we're not using `seam-pgm` in `seam-connect` though, we're bound to make mistakes with duplicated code like that 🤔 
Also, not sure why `billing` accesses the `seam-connect` database and generates its own types / schema for it, this is prone to error.